### PR TITLE
Add option to identify overlapping matches with find_iupac.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "streq"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]
 description = "Basic utilities for working with nucleotide sequence strings."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 keywords = ["nucleotide", "sequence", "science"]
 
@@ -20,13 +20,16 @@ classifiers = [
 
   "License :: OSI Approved :: MIT License",
 
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3 :: Only",
 ]
 
 dependencies = [ 
-  "pyyaml"
+  "pyyaml",
+  "regex",
 ]
 
 [project.urls]

--- a/streq/seqtools.py
+++ b/streq/seqtools.py
@@ -5,9 +5,11 @@ calculations on nucleotide sequences.
 
 """
 
+from __future__ import annotations
+
 from collections.abc import Generator, Sequence
-from difflib import SequenceMatcher
 import re
+import regex
 
 from .utils import (sequences, 
                     _preserve_case, 
@@ -139,7 +141,8 @@ def to_dna(x: str) -> str:
 
 @_normalize_case(nargs=2)
 def find_iupac(query: str, 
-               sequence: str) -> Generator[Sequence[int], str]:
+               sequence: str,
+               overlapped: bool = False,) -> Generator[Sequence[int], str]:
     
     """Find occurrences of a query in a larger sequence.
 
@@ -187,9 +190,9 @@ def find_iupac(query: str,
     """
     
     query = query.translate(seqs.base2regex)
-    query = re.compile(query) 
+    query = regex.compile(query) 
     
-    for match in query.finditer(sequence):
+    for match in regex.finditer(query, sequence, overlapped=overlapped):
 
         yield match.span(), match.group()
 


### PR DESCRIPTION
Fixes issue #3 .

Modifying find_iupac function to use regex python package (https://github.com/mrabarnett/mrab-regex, https://pypi.org/project/regex/) which allows identification of overlapping matches with finditer function. Previously used re module, which only identifies non-overlapping matches. 

In order to keep behaviour consistent in packages that use the find_iupac function, overlapping matches argument set to False as the default (ie will only identify non-overlapping matches as before). Where overlapping matches are desired, can add the overlapped=True argument in those packages to change behaviour.

Note, merged to dev branch but main branch is ahead of dev branch (and main branch files used to generate uploaded files, so some of those commits are part of this commit). 

Commits tested for find_iupac function alone, and as part of crispio generate function - behave as expected with both missing overlapped arguments (ie non-overlapping matches only) and with overlapped = True (all matches, including overlapping).